### PR TITLE
fix enter shell for conda envs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ classifiers = [
 ]
 dependencies = [
   "hatch>=1.2.0",
+  "pexpect~=4.8",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
Hi,

This change fixes `hatch shell` for conda envs. 

Code added is very similar to code used in `hatch` for python virtual envs.

Only ( `bash`, `zsh`) support added. Other shells will raise a `NotImplementedError`.

Functionality is verified manually only on `macos` X `zsh, bash`. No tests added.

Code is formatted ( `hatch env run -e lint fmt` )

Thanks,

Harel