### PR TITLE
Add support for micromamba, environment.yml file

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Added
+- A conda `environment.yml` file can specified, which will be used to set up the environment. This allows installing packages from, e.g., the `conda-forge` index.
+
 ## [0.3.2] - 09/06/2023
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ This project is a copied and modified version of the [hatch-containers](https://
   - [Python](#python)
   - [Command](#command)
   - [Conda-forge](#conda-forge)
+  - [Environment file](#environment-file)
 - [Notes](#notes)
-- [Future](#future)
 - [License](#license)
 
 ## Installation
@@ -55,7 +55,7 @@ If not set, then the `<MAJOR>.<MINOR>` version of the first `python` found along
 
 ### Command
 
-The `command` option specifies the command that will be used to setup the environment. The possible options are `conda` and `mamba`.
+The `command` option specifies the command that will be used to setup the environment. The possible options are `conda`, `mamba` and `micromamba`.
 
 Default:
 
@@ -75,14 +75,20 @@ Default:
 conda-forge = true
 ```
 
+### Environment file
+By default packages will be installed using pip. However, to install packages using conda, conda-forge, or any other channel, you can specify a conda environment file:
+
+```toml
+[envs.<ENV_NAME>]
+environment-file = "environment.yml"
+```
+
+When using an environment file, the channel and python version specified in the environment file will be used. After installing the environment, any extra packages specified in the dependencies will be installed, as well as the local package. 
+
 ## Notes
 
-- There must be a `conda` or `mamba` executable along your `PATH`.
+- There must be a `conda`, `mamba`, or `micromamba` executable along your `PATH`.
 - The `env-exclude` [environment variable filter](https://hatch.pypa.io/latest/config/environment/#filters) has no effect.
-
-## Future
-
-1. Install available packages from conda + conda-forge before using pip.
 
 ## License
 

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -130,20 +130,21 @@ class CondaEnvironment(EnvironmentInterface):
         return self._get_conda_env_path(self.conda_env_name)
 
     def create(self):
-        if not self.environment_file or self.config_command == 'micromamba':
-            command = [self.config_command, 'create', '--file', self.environment_file, '-y']
-        else:
-            command = [self.config_command, 'env', 'create']
-
-        command += ['-n', self.conda_env_name]
-
         if not self.environment_file:
+            command = [self.config_command, 'create', '-y']
             if self.config_conda_forge:
                 command += ['-c', 'conda-forge', '--no-channel-priority']
             command += [
                 f'python={self.python_version}',
                 'pip',
             ]
+        elif self.config_command == 'micromamba':
+            command = ['micromamba', 'create', '-y', '--file', self.environment_file]
+        else:
+            command = [self.config_command, 'env', 'create', '--file', self.environment_file]
+
+        command += ['-n', self.conda_env_name]
+
         if self.verbosity > 0:  # no cov
             self.platform.check_command(command)
         else:

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import os
+import re
 import shutil
 import signal
 import sys
 from contextlib import contextmanager
+from pathlib import Path
 from types import FrameType
 from typing import Callable
 
@@ -52,6 +55,7 @@ class CondaEnvironment(EnvironmentInterface):
 
         self._config_command = None
         self._config_conda_forge = None
+        self._config_environment_file = None
         self.__python_version = None
 
         self.conda_env_name = f'{self.metadata.core.name}_{self.name}_{self.python_version}'
@@ -61,7 +65,7 @@ class CondaEnvironment(EnvironmentInterface):
 
     @staticmethod
     def get_option_types():
-        return {'command': str, 'conda-forge': bool}
+        return {'command': str, 'conda-forge': bool, 'environment-file': str}
 
     def _config_value(self, field_name, default, valid=None):
         class_name = f'_config_{field_name.replace("-", "_")}'
@@ -79,11 +83,15 @@ class CondaEnvironment(EnvironmentInterface):
 
     @property
     def config_command(self):
-        return self._config_value('command', 'conda', ['conda', 'mamba'])
+        return self._config_value('command', 'conda', ['conda', 'mamba', 'micromamba'])
 
     @property
     def config_conda_forge(self):
         return self._config_value('conda-forge', True)
+
+    @property
+    def environment_file(self):
+        return self._config_value('environment-file', False)
 
     @property
     def python_version(self):
@@ -98,36 +106,44 @@ class CondaEnvironment(EnvironmentInterface):
 
         return self.__python_version
 
-    def _get_conda_env_path(self, name):
-        output = self.platform.check_command_output([self.config_command, 'env', 'list'])
-        env_names, env_paths = zip(
-            *[(line.split(' ')[0], line.split(' ')[-1]) for line in output.splitlines() if len(line.split(' ')[0]) > 1]
-        )
-        if name not in env_names:
-            return None
-        return env_paths[env_names.index(name)]
+    def _get_conda_env_path(self, name: str):
+        if self.config_command == 'micromamba':
+            output = self.platform.check_command_output([self.config_command, 'info', '--name', name])
+
+            match_env_location = r'env location : ([\S]*)\n'
+            return re.findall(match_env_location, output)[0]
+
+        else:
+            output = self.platform.check_command_output([self.config_command, 'env', 'list'])
+            env_names, env_paths = zip(
+                *[
+                    (line.split(' ')[0], line.split(' ')[-1])
+                    for line in output.splitlines()
+                    if len(line.split(' ')[0]) > 1
+                ]
+            )
+            if name not in env_names:
+                return None
+            return env_paths[env_names.index(name)]
 
     def find(self):
         return self._get_conda_env_path(self.conda_env_name)
 
     def create(self):
-        command = [
-            self.config_command,
-            'create',
-            '-y',
-            '-n',
-            self.conda_env_name,
-        ]
-        if self.config_conda_forge:
+        if not self.environment_file or self.config_command == 'micromamba':
+            command = [self.config_command, 'create', '--file', self.environment_file, '-y']
+        else:
+            command = [self.config_command, 'env', 'create']
+
+        command += ['-n', self.conda_env_name]
+
+        if not self.environment_file:
+            if self.config_conda_forge:
+                command += ['-c', 'conda-forge', '--no-channel-priority']
             command += [
-                '-c',
-                'conda-forge',
-                '--no-channel-priority',
+                f'python={self.python_version}',
+                'pip',
             ]
-        command += [
-            f'python={self.python_version}',
-            'pip',
-        ]
         if self.verbosity > 0:  # no cov
             self.platform.check_command(command)
         else:
@@ -138,7 +154,10 @@ class CondaEnvironment(EnvironmentInterface):
         self.platform.check_command_output([self.config_command, 'env', 'remove', '-y', '--name', self.conda_env_name])
 
     def exists(self):
-        return bool(self._get_conda_env_path(self.conda_env_name))
+        env_path = self._get_conda_env_path(self.conda_env_name)
+        if env_path is not None:
+            return Path(self._get_conda_env_path(self.conda_env_name)).exists()
+        return False
 
     def construct_conda_run_command(self, command):
         return [self.config_command, 'run', '-n', self.conda_env_name] + command
@@ -201,12 +220,16 @@ class CondaEnvironment(EnvironmentInterface):
             shell_executor(path, args, cmdl)
 
     def apply_env_vars(self):
-        env_vars = []
-        for env_var, value in dict(self.env_vars).items():
-            value_fixed = value
-            if sys.platform == 'win32':
-                value_fixed = value_fixed.replace('%', '%%%%%%%%')
-            env_vars.append(f'{env_var}={value_fixed}')
-        self.platform.check_command(
-            ['conda', 'env', 'config', 'vars', 'set', '-n', self.conda_env_name, '--'] + env_vars
-        )
+        if self.config_command == 'micromamba':
+            for env_var, value in dict(self.env_vars).items():
+                os.environ[env_var] = value
+        else:
+            env_vars = []
+            for env_var, value in dict(self.env_vars).items():
+                value_fixed = value
+                if sys.platform == 'win32':
+                    value_fixed = value_fixed.replace('%', '%%%%%%%%')
+                env_vars.append(f'{env_var}={value_fixed}')
+            self.platform.check_command(
+                ['conda', 'env', 'config', 'vars', 'set', '-n', self.conda_env_name, '--'] + env_vars
+            )


### PR DESCRIPTION
Hi @OldGrumpyViking, thanks for making this plugin. For my use case we needed access to a conda-forge package, as it is not available on pip ([esmpy](https://earthsystemmodeling.org/esmpy/)).

To be able to do this, I implemented a way for the user to specify an environment.yml file, which is then used for the installation.

Additionally, I made the plugin compatible with micromamba, which deviates in some small ways from conda/mamba.

Please let me know if you're interested in merging this, and if there are any changes you would like to make.