### PR TITLE
Fix cov script covering hatch_containers

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### Fixed
+- Fix `cov` script arg covering wrong package.
+
 ## [0.4.1] - 11/07/2023
 
 ### Fixed

--- a/hatch.toml
+++ b/hatch.toml
@@ -8,7 +8,7 @@ dependencies = [
 ]
 
 [envs.default.scripts]
-cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=hatch_containers --cov=tests"
+cov = "pytest --cov-report=term-missing --cov-config=pyproject.toml --cov=hatch_conda --cov=tests"
 no-cov = "cov --no-cov"
 
 [envs.lint]


### PR DESCRIPTION
This PR fixes a bad arg in the `cov` script. Super small fix. The script was trying to cover the `hatch_containers` package instead of `hatch_conda`.

CI runs were showing the error with
```
/home/runner/.local/share/hatch/env/virtual/hatch-conda/qoT-Fjnu/hatch-conda/lib/python3.11/site-packages/coverage/inorout.py:507: CoverageWarning: Module hatch_containers was never imported. (module-not-imported)
  self.warn(f"Module {pkg} was never imported.", slug="module-not-imported")
```

I _think_ `cov` script runs were still showing the right coverage data because the `source_pkgs` entry in `tool.coverage.run`was using the correct package name. 👍 

I also put an entry into HISTORY.md.