### PR TITLE
do not capture output when running commands

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - The `prefix` configuration option to specify file system location for the environment.
 
 ### Fixed
+- Fix capturing of commands output when running commands with `conda run` or alike
 - Fix `cov` script arg covering wrong package.
 
 ## [0.4.1] - 11/07/2023

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -183,7 +183,7 @@ class CondaEnvironment(EnvironmentInterface):
         return False
 
     def construct_conda_run_command(self, command):
-        head = [self.config_command, "run"]
+        head = [self.config_command, "run", "--no-capture-output"]
 
         if self.config_prefix is not None:
             head += ["--prefix", self.config_prefix]


### PR DESCRIPTION
This PR solves #13 

this PR simply aligns the behavior of `hatch-conda` with the behavior of `hatch` built in envs.

to see / reproduce the issue you can  ( this is an overkill. sorry )

```bash
➜ hatch new luli
➜ cd luli
```

add `hatch.toml` with - 

```toml
[envs.docs]
type = "conda"
command = "mamba"

dependencies = [
  "mkdocs~=1.5.3",
]
```

Init `mkdocs` - 

```bash
➜ hatch run docs:mkdocs new .
➜ hatch run docs:mkdocs serve
```

before adding `--no-capture-output` to the `mamba / conda / micromamba run` command, nothing is printed to console. after added you get -- 

```bash
➜ hatch run docs:mkdocs serve
INFO    -  Building documentation...
INFO    -  Cleaning site directory
INFO    -  Documentation built in 0.07 seconds
INFO    -  [16:34:55] Watching paths for changes: 'docs', 'mkdocs.yml'
INFO    -  [16:34:55] Serving on http://127.0.0.1:8000/
```

Thanks,

Harel
