### PR TITLE
Import dependencies_in_sync from hatchling

### DIFF
--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -213,12 +213,13 @@ class CondaEnvironment(EnvironmentInterface):
         if not self.dependencies:
             return True
         self.apply_env_vars()
-        with self:
-            process = self.platform.run_command(
-                " ".join(["hatchling", "dep", "synced", "-p", "python", *self.dependencies]),
-                capture_output=True,
+
+        from hatchling.dep.core import dependencies_in_sync
+
+        with self.safe_activation():
+            return dependencies_in_sync(
+                self.dependencies_complex, sys_path=self.virtual_env.sys_path, environment=self.virtual_env.environment
             )
-            return not process.returncode
 
     def sync_dependencies(self):
         self.apply_env_vars()

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -12,6 +12,7 @@ from typing import Callable
 
 import pexpect
 from hatch.env.plugin.interface import EnvironmentInterface
+from hatch.utils.env import PythonInfo
 
 
 class ShellManager:
@@ -216,9 +217,10 @@ class CondaEnvironment(EnvironmentInterface):
 
         from hatchling.dep.core import dependencies_in_sync
 
+        python_info = PythonInfo(self.platform)
         with self:
             return dependencies_in_sync(
-                self.dependencies_complex, sys_path=self.virtual_env.sys_path, environment=self.virtual_env.environment
+                self.dependencies_complex, sys_path=python_info.sys_path, environment=self.virtual_env.environment
             )
 
     def sync_dependencies(self):

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -220,7 +220,7 @@ class CondaEnvironment(EnvironmentInterface):
         python_info = PythonInfo(self.platform)
         with self:
             return dependencies_in_sync(
-                self.dependencies_complex, sys_path=python_info.sys_path, environment=self.virtual_env.environment
+                self.dependencies_complex, sys_path=python_info.sys_path, environment=python_info.environment
             )
 
     def sync_dependencies(self):

--- a/hatch_conda/plugin.py
+++ b/hatch_conda/plugin.py
@@ -216,7 +216,7 @@ class CondaEnvironment(EnvironmentInterface):
 
         from hatchling.dep.core import dependencies_in_sync
 
-        with self.safe_activation():
+        with self:
             return dependencies_in_sync(
                 self.dependencies_complex, sys_path=self.virtual_env.sys_path, environment=self.virtual_env.environment
             )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ classifiers = [
 ]
 dependencies = [
   "hatch>=1.2.0",
+  "hatchling>=1.0.0",
   "pexpect~=4.8",
 ]
 dynamic = ["version"]


### PR DESCRIPTION
Imports `dependencies_in_sync` from hatchling to check whether dependencies are synced, instead of using the hatching CLI via a shell command. This means that hatching just needs to be installed in the same environment as hatch/hatch-conda, but doesn't need it's CLI entrypoint to be available on the user's PATH. 

This implementation is based on how hatch implements `VirtualEnvironment.dependencies_in_sync`.

https://github.com/pypa/hatch/blob/cfa05386f9dc4a029462a23a38d0885176efbaac/src/hatch/env/virtual.py#L128-L137

Closes #27. 


Tested with pipx in a project using hatch-conda in the default environment:

```bash
pipx install hatch
pipx inject hatch git+https://github.com/jayqi/hatch-conda.git@27-fix-filenotfounderror-hatchling
hatch env create
```